### PR TITLE
🚀 Release v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "otplus-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otplus-core"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Core cryptographic library for OTPlus - A secure one-time password and key derivation system"
 license = "MIT"


### PR DESCRIPTION
## 📦 Version Bump Release

This PR bumps the version from the current version to **v0.0.3** using a **patch** bump.

### Changes
- Bump version in `Cargo.toml` to 0.0.3
- Update `Cargo.lock` to reflect version changes

### Next Steps
1. Review and approve this PR
2. Merge this PR to main
3. The release workflow will automatically publish to crates.io

**Auto-generated by Release Workflow**